### PR TITLE
minor correction => handlers for ICommand & IQuery had been swapped

### DIFF
--- a/After/src/Logic/Students/ICommand.cs
+++ b/After/src/Logic/Students/ICommand.cs
@@ -1,12 +1,16 @@
-﻿namespace Logic.Students
+﻿using CSharpFunctionalExtensions;
+
+namespace Logic.Students
 {
     public interface ICommand
     {
     }
 
-    public interface IQueryHandler<TQuery, TResult>
-        where TQuery : IQuery<TResult>
+    public interface ICommandHandler<TCommand>
+        where TCommand : ICommand
     {
-        TResult Handle(TQuery query);
+        Result Handle(TCommand command);
     }
+
+
 }

--- a/After/src/Logic/Students/IQuery.cs
+++ b/After/src/Logic/Students/IQuery.cs
@@ -1,14 +1,12 @@
-﻿using CSharpFunctionalExtensions;
-
-namespace Logic.Students
+﻿namespace Logic.Students
 {
     public interface IQuery<TResult>
     {
     }
 
-    public interface ICommandHandler<TCommand>
-        where TCommand : ICommand
+    public interface IQueryHandler<TQuery, TResult>
+        where TQuery : IQuery<TResult>
     {
-        Result Handle(TCommand command);
+        TResult Handle(TQuery query);
     }
 }


### PR DESCRIPTION
Hi Vladmir, 

I guess the handlers got swapped in ICommand.cs and IQuery.cs. 
Just a readability improvement.

Regards,
Hari