### PR TITLE
remove slash between variables to fix invalid api calls

### DIFF
--- a/Before/src/UI/Api/ApiClient.cs
+++ b/Before/src/UI/Api/ApiClient.cs
@@ -46,7 +46,7 @@ namespace UI.Api
         private static async Task<Result<T>> SendRequest<T>(string url, HttpMethod method, object content = null)
              where T : class
         {
-            var request = new HttpRequestMessage(method, $"{_endpointUrl}/{url}");
+            var request = new HttpRequestMessage(method, $"{_endpointUrl}{url}");
             if (content != null)
             {
                 request.Content = new StringContent(JsonConvert.SerializeObject(content), Encoding.UTF8, "application/json");


### PR DESCRIPTION
$"{_endpointUrl}{url}"

Originally, the UI would send this request, which would fail:
![image](https://user-images.githubusercontent.com/1403107/71328733-0a2eae00-24ea-11ea-97cb-07401681eca2.png)

With the new formatted string, it sends the proper request, which passes:
![image](https://user-images.githubusercontent.com/1403107/71328745-1d417e00-24ea-11ea-844d-c056c245bbde.png)
